### PR TITLE
fix: example test

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "generate": "pnpm run db:generate",
-    "db:generate": "dotenv -e .env.local -- prisma generate && dotenv -e .env.local -- prisma generate --data-proxy",
+    "db:generate": "dotenv -e .env.local -- prisma generate && dotenv -e .env.local -- prisma generate",
     "db:push": "dotenv -e .env.local -- prisma db push --skip-generate",
     "db:seed": "dotenv -e .env.local -- prisma db seed",
     "cleanup": "rm -rf pnpm-lock.yaml yarn.lock package-lock.json deno.lock node_modules/",
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit",
     "format:write": "deno fmt",
     "format:check": "deno fmt --check",
-    "test:run": "deno test",
+    "test:run": "deno test --allow-all",
     "test": "deno test --watch"
   },
   "dependencies": {

--- a/packages/api/supabase/functions/_shared/supabase-client.ts
+++ b/packages/api/supabase/functions/_shared/supabase-client.ts
@@ -1,4 +1,6 @@
 import { createClient, type SupabaseClient } from "@supabase";
+import { config } from "https://deno.land/x/dotenv/mod.ts";
+await config({ export: true });
 
 const getSupabaseClient = (
   url?: string,

--- a/packages/api/supabase/functions/profile-create/mod.ts
+++ b/packages/api/supabase/functions/profile-create/mod.ts
@@ -102,9 +102,6 @@ const profileCreate = async (
 
     showStories: profileValidated.showStories ?? false,
     showMembers: profileValidated.showMembers ?? false,
-
-    title: defaultTranslation?.title ?? "",
-    description: defaultTranslation?.description ?? "",
   };
 
   const profileQueryResponse = await supabase


### PR DESCRIPTION
@eser  Merhaba öncelikle.

Test ile ilgili geliştirmeleri yapmayı planlıyorum fakat projeyi çalıştırırken birkaç durumlar karşılaştım ve bu pr bu durumlar için açıyorum.

1. Api bölümünde package.json içerisinde örnek database'i seed etmek istediğimde --data-proxy sebebiyle .env.local içerisindeki database url prisma:// prefix eklememi istedi. Sadece projenin geçmişinde de bu düzeltme var fakat sonrasında tekrar eski haline dönmüş. Ben tekrar --data-proxy kaldırmadan database'i seed edemedim çünkü bağlanmadı.

2. Supabase client içerisinde Deno.env ile env dosyasına erişemedim, araştırdığımda bu şeklinde config eklemesi yapılarak çözüldüğünü gördüm ve bu şeklinde yapınca sorunum çözüldü. Böylelikle testlerde supabase .env dosyasında okuyarak bağlantıyı kurabildi.

3. Test bölümünde client mock ile çalışıyordu bunu kaldırdım ve supabase en üstte ekledim. En üste ekleme sebebim deno içerisinde Op sanitizer database açık kaldığı için error verip testi fail ediyordu. En üste alınca bu sorun çözüldü yada çözüm olarak Op sanitizer disable etmek ve db bağlantısı kapatma gibi durumlar vardı.

4. Profile create bölümünde tipler ile database üzerinde bölümler uyuşmuyordu bu sebeple uyuşmayan fieldları  yani title ve descriptionu çıkardım.

5. Örnek test içerisinde aynı slug ile işlem olduğu için tekrar edilen testlerde slug uyarısı veriyordu, tüm testlerin sonunda slugları silmek için de bi ekleme yaptım.

Test bölümünü tamamen gördüğüm kadarıyla düzenledim, eksik/fazla bölümler olabilir bunları tespit etmek için en doğru yolun pr üzerinden gitmek olduğunu düşünüyorum. Bu pr ile ilgili işlemler tamamlanınca diğer testleri ayrı bir pr içerisinde açıp göndermeyi planlıyorum.